### PR TITLE
Add 05_src/data/* to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 *.parquet
 *.log
 **/__pycache__/*
+05_src/data/*


### PR DESCRIPTION
This PR adds 05_src/data/ to gitignore to make sure no one commits data to the repository.